### PR TITLE
Fix iam policy referencing and add KMS

### DIFF
--- a/src/kms-key.tf
+++ b/src/kms-key.tf
@@ -1,0 +1,90 @@
+module "kms_key_archive" {
+  source  = "cloudposse/kms-key/aws"
+  version = "0.12.2"
+
+  description             = "KMS key for Datadog Log Archives"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = join("", data.aws_iam_policy_document.kms_key_archive[*].json)
+
+  context = module.this.context
+}
+
+data "aws_iam_policy_document" "kms_key_archive" {
+  count = local.enabled ? 1 : 0
+
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        format("arn:${local.aws_partition}:iam::%s:root", local.aws_account_id)
+      ]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow CloudTrail to use the key" 
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions = [
+      "kms:Encrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:cloudtrail:arn"
+      values = [
+        format("arn:${local.aws_partition}:cloudtrail:*:%s:trail/*", local.aws_account_id)
+      ]
+    }
+  }
+
+  statement {
+    sid    = "Allow use of the key"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        format("arn:${local.aws_partition}:iam::%s:role/${local.datadog_aws_role_name}", local.aws_account_id)
+      ]
+    }
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt", 
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow attachment of persistent resources"
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        format("arn:${local.aws_partition}:iam::%s:role/${local.datadog_aws_role_name}", local.aws_account_id)
+      ]
+    }
+    actions = [
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:RevokeGrant"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
+  }
+}

--- a/src/main.tf
+++ b/src/main.tf
@@ -140,7 +140,9 @@ module "bucket_policy" {
   source  = "cloudposse/iam-policy/aws"
   version = "2.0.2"
 
-  iam_policy_statements = try(lookup(local.policy, "Statement"), null)
+  iam_policy = local.enabled ? {
+    statements = local.policy.Statement
+  } : null
 
   context = module.this.context
 }

--- a/src/main.tf
+++ b/src/main.tf
@@ -169,6 +169,9 @@ module "archive_bucket" {
   enabled       = local.enabled
   force_destroy = var.s3_force_destroy
 
+  kms_master_key_arn = module.kms_key_archive.key_arn
+  sse_algorithm      = "aws:kms"
+
   lifecycle_rules = [
     {
       prefix  = null
@@ -231,6 +234,9 @@ module "cloudtrail_s3_bucket" {
   enabled       = local.enabled
   force_destroy = var.s3_force_destroy
 
+  kms_master_key_arn = module.kms_key_archive.key_arn
+  sse_algorithm      = "aws:kms"
+
   source_policy_documents = data.aws_iam_policy_document.default.*.json
 
   lifecycle_rules = [
@@ -241,8 +247,8 @@ module "cloudtrail_s3_bucket" {
 
       abort_incomplete_multipart_upload_days         = null
       enable_glacier_transition                      = var.enable_glacier_transition
-      glacier_transition_days                        = 365
-      noncurrent_version_glacier_transition_days     = 365
+      glacier_transition_days                        = var.glacier_transition_days
+      noncurrent_version_glacier_transition_days     = var.glacier_transition_days
       enable_deeparchive_transition                  = false
       deeparchive_transition_days                    = 0
       noncurrent_version_deeparchive_transition_days = 0
@@ -304,6 +310,7 @@ module "cloudtrail" {
   enabled                       = local.enabled
   enable_logging                = true
   s3_bucket_name                = module.cloudtrail_s3_bucket[0].bucket_id
+  kms_key_arn                   = module.kms_key_archive.key_arn
 
   event_selector = [
     {


### PR DESCRIPTION
## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

I changed how the IAM Bucket policy is reference in order to fix an error I was getting.

Additionally for [compliance](https://help.drata.com/en/articles/9828725-test-222-aws-cloudtrail-logs-encrypted) I have included changes to use CMK KMS as well.

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

I was experiencing this error:
```
Error: Invalid value for input variable

  on main.tf line 143, in module "bucket_policy":
  143:   iam_policy_statements = try(lookup(local.policy, "Statement"), null)

The given value is not suitable for module.bucket_policy.var.iam_policy_statements declared at .terraform/modules/bucket_policy/variables.tf:37,1-33: map of object required.
```
And because https://github.com/cloudposse/terraform-aws-iam-policy/blob/660de2d894c7b4aebd8f98bd061faad5b028a107/variables.tf#L37-L65 requires a map of objects, I needed to change how the policy was being referenced in order to fulfill that requirement.



## Other details

I also in my stack needed to add a name, otherwise I'd get the following errors:
```
    datadog-logs-archive:
      vars:
        enabled: true
        name: datadog-logs-archive
        catchall_enabled: true
        enable_glacier_transition: true
        glacier_transition_days: 365
```

Errors:
```
module.cloudtrail_s3_bucket[0].aws_s3_bucket_lifecycle_configuration.default[0]: Creation complete after 32s [id=hl-core-uw2-audit-datadog-logs-archive-cloudtrail]
module.cloudtrail_s3_bucket[0].aws_s3_bucket_policy.default[0]: Still creating... [40s elapsed]
module.cloudtrail_s3_bucket[0].aws_s3_bucket_policy.default[0]: Still creating... [50s elapsed]
module.cloudtrail_s3_bucket[0].aws_s3_bucket_policy.default[0]: Still creating... [1m0s elapsed]
module.cloudtrail_s3_bucket[0].aws_s3_bucket_policy.default[0]: Still creating... [1m10s elapsed]
module.cloudtrail_s3_bucket[0].aws_s3_bucket_policy.default[0]: Still creating... [1m20s elapsed]
module.cloudtrail_s3_bucket[0].aws_s3_bucket_policy.default[0]: Still creating... [1m30s elapsed]
module.cloudtrail_s3_bucket[0].aws_s3_bucket_policy.default[0]: Still creating... [1m40s elapsed]
module.cloudtrail_s3_bucket[0].aws_s3_bucket_policy.default[0]: Still creating... [1m50s elapsed]
╷
│ Error: putting S3 Bucket (hl-core-uw2-audit-datadog-logs-archive-cloudtrail) Policy: operation error S3: PutBucketPolicy, https response error StatusCode: 400, RequestID: N4BWPTREK6FJWBPK, HostID: an/L2NP8qnWpmFMujsJPJsu1LgCaLHKmEDMffuZDlM5webavxIIRQjRLOcI+Vqx1/XJfUI0iYr0=, api error MalformedPolicy: Policy has invalid resource
│ 
│   with module.cloudtrail_s3_bucket[0].aws_s3_bucket_policy.default[0],
│   on .terraform/modules/cloudtrail_s3_bucket/main.tf line 461, in resource "aws_s3_bucket_policy" "default":
│  461: resource "aws_s3_bucket_policy" "default" {
│ 
╵
exit status 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added encryption with AWS KMS for S3 buckets and CloudTrail logs.
  - Introduced a dedicated KMS key for Datadog Log Archives with detailed access policies.
  - Made Glacier transition days configurable for CloudTrail bucket lifecycle rules.
- **Refactor**
  - Updated IAM policy configuration to a conditional and structured format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->