### PR TITLE
fix bad module reference

### DIFF
--- a/src/provider-datadog.tf
+++ b/src/provider-datadog.tf
@@ -1,5 +1,5 @@
 module "datadog_configuration" {
-  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials?ref=v1.535.6"
+  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys?ref=v1.535.6"
   enabled = true
   context = module.this.context
 }


### PR DESCRIPTION
## what
* fix module reference

## why
* component is currently broken due to bad module reference

## references
* https://github.com/cloudposse-terraform-components/aws-datadog-logs-archive/commit/ee5723f50098333ff9169fb833cfe38c08b83bc9
* closes https://github.com/cloudposse-terraform-components/aws-datadog-logs-archive/issues/51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the source path for the Datadog configuration module to use a more specific subdirectory. No functional changes to existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->