### PR TITLE
Feature - flexible s3 lifecycle rules

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -182,10 +182,10 @@ module "archive_bucket" {
       noncurrent_version_deeparchive_transition_days = 0
       enable_standard_ia_transition                  = false
       standard_transition_days                       = 0
-      enable_current_object_expiration               = false
-      expiration_days                                = 0
-      enable_noncurrent_version_expiration           = false
-      noncurrent_version_expiration_days             = 0
+      enable_current_object_expiration               = var.expiration_days > 0
+      expiration_days                                = var.expiration_days
+      enable_noncurrent_version_expiration           = var.noncurrent_version_expiration_days > 0
+      noncurrent_version_expiration_days             = var.noncurrent_version_expiration_days
     },
   ]
 
@@ -246,10 +246,10 @@ module "cloudtrail_s3_bucket" {
       noncurrent_version_deeparchive_transition_days = 0
       enable_standard_ia_transition                  = false
       standard_transition_days                       = 0
-      enable_current_object_expiration               = false
-      expiration_days                                = 0
-      enable_noncurrent_version_expiration           = false
-      noncurrent_version_expiration_days             = 0
+      enable_current_object_expiration               = var.expiration_days > 0
+      expiration_days                                = var.expiration_days
+      enable_noncurrent_version_expiration           = var.noncurrent_version_expiration_days > 0
+      noncurrent_version_expiration_days             = var.noncurrent_version_expiration_days
     },
   ]
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -237,19 +237,19 @@ module "cloudtrail_s3_bucket" {
       enabled = var.lifecycle_rules_enabled
       tags    = {}
 
-      abort_incomplete_multipart_upload_days         = var.abort_incomplete_multipart_upload_days
-      enable_glacier_transition                      = var.enable_glacier_transition
+      abort_incomplete_multipart_upload_days         = var.cloudtrail_abort_incomplete_multipart_upload_days
+      enable_glacier_transition                      = var.cloudtrail_enable_glacier_transition
       glacier_transition_days                        = var.cloudtrail_glacier_transition_days
       noncurrent_version_glacier_transition_days     = var.cloudtrail_noncurrent_version_glacier_transition_days
-      enable_deeparchive_transition                  = var.enable_deeparchive_transition
-      deeparchive_transition_days                    = var.deeparchive_transition_days
-      noncurrent_version_deeparchive_transition_days = var.noncurrent_version_deeparchive_transition_days
-      enable_standard_ia_transition                  = var.enable_standard_ia_transition
-      standard_transition_days                       = var.standard_transition_days
-      enable_current_object_expiration               = var.expiration_days > 0
-      expiration_days                                = var.expiration_days
-      enable_noncurrent_version_expiration           = var.noncurrent_version_expiration_days > 0
-      noncurrent_version_expiration_days             = var.noncurrent_version_expiration_days
+      enable_deeparchive_transition                  = var.cloudtrail_enable_deeparchive_transition
+      deeparchive_transition_days                    = var.cloudtrail_deeparchive_transition_days
+      noncurrent_version_deeparchive_transition_days = var.cloudtrail_noncurrent_version_deeparchive_transition_days
+      enable_standard_ia_transition                  = var.cloudtrail_enable_standard_ia_transition
+      standard_transition_days                       = var.cloudtrail_standard_transition_days
+      enable_current_object_expiration               = var.cloudtrail_expiration_days > 0
+      expiration_days                                = var.cloudtrail_expiration_days
+      enable_noncurrent_version_expiration           = var.cloudtrail_noncurrent_version_expiration_days > 0
+      noncurrent_version_expiration_days             = var.cloudtrail_noncurrent_version_expiration_days
     },
   ]
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -173,19 +173,19 @@ module "archive_bucket" {
       enabled = var.lifecycle_rules_enabled
       tags    = {}
 
-      abort_incomplete_multipart_upload_days         = var.abort_incomplete_multipart_upload_days
-      enable_glacier_transition                      = var.enable_glacier_transition
-      glacier_transition_days                        = var.glacier_transition_days
-      noncurrent_version_glacier_transition_days     = var.noncurrent_version_glacier_transition_days
-      enable_deeparchive_transition                  = var.enable_deeparchive_transition
-      deeparchive_transition_days                    = var.deeparchive_transition_days
-      noncurrent_version_deeparchive_transition_days = var.noncurrent_version_deeparchive_transition_days
-      enable_standard_ia_transition                  = var.enable_standard_ia_transition
-      standard_transition_days                       = var.standard_transition_days
-      enable_current_object_expiration               = var.expiration_days > 0
-      expiration_days                                = var.expiration_days
-      enable_noncurrent_version_expiration           = var.noncurrent_version_expiration_days > 0
-      noncurrent_version_expiration_days             = var.noncurrent_version_expiration_days
+      abort_incomplete_multipart_upload_days         = var.archive_lifecycle_config.abort_incomplete_multipart_upload_days
+      enable_glacier_transition                      = var.archive_lifecycle_config.enable_glacier_transition
+      glacier_transition_days                        = var.archive_lifecycle_config.glacier_transition_days
+      noncurrent_version_glacier_transition_days     = var.archive_lifecycle_config.noncurrent_version_glacier_transition_days
+      enable_deeparchive_transition                  = var.archive_lifecycle_config.enable_deeparchive_transition
+      deeparchive_transition_days                    = var.archive_lifecycle_config.deeparchive_transition_days
+      noncurrent_version_deeparchive_transition_days = var.archive_lifecycle_config.noncurrent_version_deeparchive_transition_days
+      enable_standard_ia_transition                  = var.archive_lifecycle_config.enable_standard_ia_transition
+      standard_transition_days                       = var.archive_lifecycle_config.standard_transition_days
+      enable_current_object_expiration               = var.archive_lifecycle_config.expiration_days > 0
+      expiration_days                                = var.archive_lifecycle_config.expiration_days
+      enable_noncurrent_version_expiration           = var.archive_lifecycle_config.noncurrent_version_expiration_days > 0
+      noncurrent_version_expiration_days             = var.archive_lifecycle_config.noncurrent_version_expiration_days
     },
   ]
 
@@ -237,19 +237,19 @@ module "cloudtrail_s3_bucket" {
       enabled = var.lifecycle_rules_enabled
       tags    = {}
 
-      abort_incomplete_multipart_upload_days         = var.cloudtrail_abort_incomplete_multipart_upload_days
-      enable_glacier_transition                      = var.cloudtrail_enable_glacier_transition
-      glacier_transition_days                        = var.cloudtrail_glacier_transition_days
-      noncurrent_version_glacier_transition_days     = var.cloudtrail_noncurrent_version_glacier_transition_days
-      enable_deeparchive_transition                  = var.cloudtrail_enable_deeparchive_transition
-      deeparchive_transition_days                    = var.cloudtrail_deeparchive_transition_days
-      noncurrent_version_deeparchive_transition_days = var.cloudtrail_noncurrent_version_deeparchive_transition_days
-      enable_standard_ia_transition                  = var.cloudtrail_enable_standard_ia_transition
-      standard_transition_days                       = var.cloudtrail_standard_transition_days
-      enable_current_object_expiration               = var.cloudtrail_expiration_days > 0
-      expiration_days                                = var.cloudtrail_expiration_days
-      enable_noncurrent_version_expiration           = var.cloudtrail_noncurrent_version_expiration_days > 0
-      noncurrent_version_expiration_days             = var.cloudtrail_noncurrent_version_expiration_days
+      abort_incomplete_multipart_upload_days         = var.cloudtrail_lifecycle_config.abort_incomplete_multipart_upload_days
+      enable_glacier_transition                      = var.cloudtrail_lifecycle_config.enable_glacier_transition
+      glacier_transition_days                        = var.cloudtrail_lifecycle_config.glacier_transition_days
+      noncurrent_version_glacier_transition_days     = var.cloudtrail_lifecycle_config.noncurrent_version_glacier_transition_days
+      enable_deeparchive_transition                  = var.cloudtrail_lifecycle_config.enable_deeparchive_transition
+      deeparchive_transition_days                    = var.cloudtrail_lifecycle_config.deeparchive_transition_days
+      noncurrent_version_deeparchive_transition_days = var.cloudtrail_lifecycle_config.noncurrent_version_deeparchive_transition_days
+      enable_standard_ia_transition                  = var.cloudtrail_lifecycle_config.enable_standard_ia_transition
+      standard_transition_days                       = var.cloudtrail_lifecycle_config.standard_transition_days
+      enable_current_object_expiration               = var.cloudtrail_lifecycle_config.expiration_days > 0
+      expiration_days                                = var.cloudtrail_lifecycle_config.expiration_days
+      enable_noncurrent_version_expiration           = var.cloudtrail_lifecycle_config.noncurrent_version_expiration_days > 0
+      noncurrent_version_expiration_days             = var.cloudtrail_lifecycle_config.noncurrent_version_expiration_days
     },
   ]
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -173,15 +173,15 @@ module "archive_bucket" {
       enabled = var.lifecycle_rules_enabled
       tags    = {}
 
-      abort_incomplete_multipart_upload_days         = null
+      abort_incomplete_multipart_upload_days         = var.abort_incomplete_multipart_upload_days
       enable_glacier_transition                      = var.enable_glacier_transition
       glacier_transition_days                        = var.glacier_transition_days
-      noncurrent_version_glacier_transition_days     = 30
-      enable_deeparchive_transition                  = false
-      deeparchive_transition_days                    = 0
-      noncurrent_version_deeparchive_transition_days = 0
-      enable_standard_ia_transition                  = false
-      standard_transition_days                       = 0
+      noncurrent_version_glacier_transition_days     = var.noncurrent_version_glacier_transition_days
+      enable_deeparchive_transition                  = var.enable_deeparchive_transition
+      deeparchive_transition_days                    = var.deeparchive_transition_days
+      noncurrent_version_deeparchive_transition_days = var.noncurrent_version_deeparchive_transition_days
+      enable_standard_ia_transition                  = var.enable_standard_ia_transition
+      standard_transition_days                       = var.standard_transition_days
       enable_current_object_expiration               = var.expiration_days > 0
       expiration_days                                = var.expiration_days
       enable_noncurrent_version_expiration           = var.noncurrent_version_expiration_days > 0
@@ -237,15 +237,15 @@ module "cloudtrail_s3_bucket" {
       enabled = var.lifecycle_rules_enabled
       tags    = {}
 
-      abort_incomplete_multipart_upload_days         = null
+      abort_incomplete_multipart_upload_days         = var.abort_incomplete_multipart_upload_days
       enable_glacier_transition                      = var.enable_glacier_transition
-      glacier_transition_days                        = 365
-      noncurrent_version_glacier_transition_days     = 365
-      enable_deeparchive_transition                  = false
-      deeparchive_transition_days                    = 0
-      noncurrent_version_deeparchive_transition_days = 0
-      enable_standard_ia_transition                  = false
-      standard_transition_days                       = 0
+      glacier_transition_days                        = var.cloudtrail_glacier_transition_days
+      noncurrent_version_glacier_transition_days     = var.cloudtrail_noncurrent_version_glacier_transition_days
+      enable_deeparchive_transition                  = var.enable_deeparchive_transition
+      deeparchive_transition_days                    = var.deeparchive_transition_days
+      noncurrent_version_deeparchive_transition_days = var.noncurrent_version_deeparchive_transition_days
+      enable_standard_ia_transition                  = var.enable_standard_ia_transition
+      standard_transition_days                       = var.standard_transition_days
       enable_current_object_expiration               = var.expiration_days > 0
       expiration_days                                = var.expiration_days
       enable_noncurrent_version_expiration           = var.noncurrent_version_expiration_days > 0

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -21,17 +21,42 @@ variable "lifecycle_rules_enabled" {
   default     = true
 }
 
-variable "enable_glacier_transition" {
-  type        = bool
-  description = "Enable/disable transition to glacier for log archive bucket. Has no effect unless lifecycle_rules_enabled set to true"
-  default     = true
+variable "archive_lifecycle_config" {
+  type = object({
+    abort_incomplete_multipart_upload_days         = optional(number, null)
+    enable_glacier_transition                      = optional(bool, true)
+    glacier_transition_days                        = optional(number, 365)
+    noncurrent_version_glacier_transition_days     = optional(number, 30)
+    enable_deeparchive_transition                  = optional(bool, false)
+    deeparchive_transition_days                    = optional(number, 0)
+    noncurrent_version_deeparchive_transition_days = optional(number, 0)
+    enable_standard_ia_transition                  = optional(bool, false)
+    standard_transition_days                       = optional(number, 0)
+    expiration_days                                = optional(number, 0)
+    noncurrent_version_expiration_days             = optional(number, 0)
+  })
+  description = "Lifecycle configuration for the archive S3 bucket"
+  default     = {}
 }
 
-variable "glacier_transition_days" {
-  type        = number
-  description = "Number of days after which to transition objects to glacier storage in log archive bucket"
-  default     = 365
+variable "cloudtrail_lifecycle_config" {
+  type = object({
+    abort_incomplete_multipart_upload_days         = optional(number, null)
+    enable_glacier_transition                      = optional(bool, true)
+    glacier_transition_days                        = optional(number, 365)
+    noncurrent_version_glacier_transition_days     = optional(number, 365)
+    enable_deeparchive_transition                  = optional(bool, false)
+    deeparchive_transition_days                    = optional(number, 0)
+    noncurrent_version_deeparchive_transition_days = optional(number, 0)
+    enable_standard_ia_transition                  = optional(bool, false)
+    standard_transition_days                       = optional(number, 0)
+    expiration_days                                = optional(number, 0)
+    noncurrent_version_expiration_days             = optional(number, 0)
+  })
+  description = "Lifecycle configuration for the cloudtrail S3 bucket"
+  default     = {}
 }
+
 
 variable "object_lock_days_archive" {
   type        = number
@@ -63,122 +88,4 @@ variable "s3_force_destroy" {
   default     = false
 }
 
-variable "expiration_days" {
-  type        = number
-  description = "Number of days after which to expire current version objects in S3 bucket. Set to 0 to disable expiration"
-  default     = 0
-}
 
-variable "noncurrent_version_expiration_days" {
-  type        = number
-  description = "Number of days after which to expire noncurrent version objects in S3 bucket. Set to 0 to disable expiration"
-  default     = 0
-}
-
-variable "abort_incomplete_multipart_upload_days" {
-  type        = number
-  description = "Number of days after which to abort incomplete multipart uploads. Set to null to disable"
-  default     = null
-}
-
-variable "noncurrent_version_glacier_transition_days" {
-  type        = number
-  description = "Number of days after which to transition noncurrent versions to glacier storage"
-  default     = 30
-}
-
-variable "enable_deeparchive_transition" {
-  type        = bool
-  description = "Enable/disable transition to deep archive storage"
-  default     = false
-}
-
-variable "deeparchive_transition_days" {
-  type        = number
-  description = "Number of days after which to transition objects to deep archive storage"
-  default     = 0
-}
-
-variable "noncurrent_version_deeparchive_transition_days" {
-  type        = number
-  description = "Number of days after which to transition noncurrent versions to deep archive storage"
-  default     = 0
-}
-
-variable "enable_standard_ia_transition" {
-  type        = bool
-  description = "Enable/disable transition to standard IA storage"
-  default     = false
-}
-
-variable "standard_transition_days" {
-  type        = number
-  description = "Number of days after which to transition objects to standard IA storage"
-  default     = 0
-}
-
-variable "cloudtrail_abort_incomplete_multipart_upload_days" {
-  type        = number
-  description = "Number of days after which to abort incomplete multipart uploads for cloudtrail bucket. Set to null to disable"
-  default     = null
-}
-
-variable "cloudtrail_enable_glacier_transition" {
-  type        = bool
-  description = "Enable/disable transition to glacier for cloudtrail bucket"
-  default     = true
-}
-
-variable "cloudtrail_glacier_transition_days" {
-  type        = number
-  description = "Number of days after which to transition cloudtrail objects to glacier storage"
-  default     = 365
-}
-
-variable "cloudtrail_noncurrent_version_glacier_transition_days" {
-  type        = number
-  description = "Number of days after which to transition cloudtrail noncurrent versions to glacier storage"
-  default     = 365
-}
-
-variable "cloudtrail_enable_deeparchive_transition" {
-  type        = bool
-  description = "Enable/disable transition to deep archive storage for cloudtrail bucket"
-  default     = false
-}
-
-variable "cloudtrail_deeparchive_transition_days" {
-  type        = number
-  description = "Number of days after which to transition cloudtrail objects to deep archive storage"
-  default     = 0
-}
-
-variable "cloudtrail_noncurrent_version_deeparchive_transition_days" {
-  type        = number
-  description = "Number of days after which to transition cloudtrail noncurrent versions to deep archive storage"
-  default     = 0
-}
-
-variable "cloudtrail_enable_standard_ia_transition" {
-  type        = bool
-  description = "Enable/disable transition to standard IA storage for cloudtrail bucket"
-  default     = false
-}
-
-variable "cloudtrail_standard_transition_days" {
-  type        = number
-  description = "Number of days after which to transition cloudtrail objects to standard IA storage"
-  default     = 0
-}
-
-variable "cloudtrail_expiration_days" {
-  type        = number
-  description = "Number of days after which to expire current version cloudtrail objects. Set to 0 to disable expiration"
-  default     = 0
-}
-
-variable "cloudtrail_noncurrent_version_expiration_days" {
-  type        = number
-  description = "Number of days after which to expire noncurrent version cloudtrail objects. Set to 0 to disable expiration"
-  default     = 0
-}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -62,3 +62,15 @@ variable "s3_force_destroy" {
   description = "Set to true to delete non-empty buckets when enabled is set to false"
   default     = false
 }
+
+variable "expiration_days" {
+  type        = number
+  description = "Number of days after which to expire current version objects in S3 bucket. Set to 0 to disable expiration"
+  default     = 0
+}
+
+variable "noncurrent_version_expiration_days" {
+  type        = number
+  description = "Number of days after which to expire noncurrent version objects in S3 bucket. Set to 0 to disable expiration"
+  default     = 0
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -117,6 +117,18 @@ variable "standard_transition_days" {
   default     = 0
 }
 
+variable "cloudtrail_abort_incomplete_multipart_upload_days" {
+  type        = number
+  description = "Number of days after which to abort incomplete multipart uploads for cloudtrail bucket. Set to null to disable"
+  default     = null
+}
+
+variable "cloudtrail_enable_glacier_transition" {
+  type        = bool
+  description = "Enable/disable transition to glacier for cloudtrail bucket"
+  default     = true
+}
+
 variable "cloudtrail_glacier_transition_days" {
   type        = number
   description = "Number of days after which to transition cloudtrail objects to glacier storage"
@@ -127,4 +139,46 @@ variable "cloudtrail_noncurrent_version_glacier_transition_days" {
   type        = number
   description = "Number of days after which to transition cloudtrail noncurrent versions to glacier storage"
   default     = 365
+}
+
+variable "cloudtrail_enable_deeparchive_transition" {
+  type        = bool
+  description = "Enable/disable transition to deep archive storage for cloudtrail bucket"
+  default     = false
+}
+
+variable "cloudtrail_deeparchive_transition_days" {
+  type        = number
+  description = "Number of days after which to transition cloudtrail objects to deep archive storage"
+  default     = 0
+}
+
+variable "cloudtrail_noncurrent_version_deeparchive_transition_days" {
+  type        = number
+  description = "Number of days after which to transition cloudtrail noncurrent versions to deep archive storage"
+  default     = 0
+}
+
+variable "cloudtrail_enable_standard_ia_transition" {
+  type        = bool
+  description = "Enable/disable transition to standard IA storage for cloudtrail bucket"
+  default     = false
+}
+
+variable "cloudtrail_standard_transition_days" {
+  type        = number
+  description = "Number of days after which to transition cloudtrail objects to standard IA storage"
+  default     = 0
+}
+
+variable "cloudtrail_expiration_days" {
+  type        = number
+  description = "Number of days after which to expire current version cloudtrail objects. Set to 0 to disable expiration"
+  default     = 0
+}
+
+variable "cloudtrail_noncurrent_version_expiration_days" {
+  type        = number
+  description = "Number of days after which to expire noncurrent version cloudtrail objects. Set to 0 to disable expiration"
+  default     = 0
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -74,3 +74,57 @@ variable "noncurrent_version_expiration_days" {
   description = "Number of days after which to expire noncurrent version objects in S3 bucket. Set to 0 to disable expiration"
   default     = 0
 }
+
+variable "abort_incomplete_multipart_upload_days" {
+  type        = number
+  description = "Number of days after which to abort incomplete multipart uploads. Set to null to disable"
+  default     = null
+}
+
+variable "noncurrent_version_glacier_transition_days" {
+  type        = number
+  description = "Number of days after which to transition noncurrent versions to glacier storage"
+  default     = 30
+}
+
+variable "enable_deeparchive_transition" {
+  type        = bool
+  description = "Enable/disable transition to deep archive storage"
+  default     = false
+}
+
+variable "deeparchive_transition_days" {
+  type        = number
+  description = "Number of days after which to transition objects to deep archive storage"
+  default     = 0
+}
+
+variable "noncurrent_version_deeparchive_transition_days" {
+  type        = number
+  description = "Number of days after which to transition noncurrent versions to deep archive storage"
+  default     = 0
+}
+
+variable "enable_standard_ia_transition" {
+  type        = bool
+  description = "Enable/disable transition to standard IA storage"
+  default     = false
+}
+
+variable "standard_transition_days" {
+  type        = number
+  description = "Number of days after which to transition objects to standard IA storage"
+  default     = 0
+}
+
+variable "cloudtrail_glacier_transition_days" {
+  type        = number
+  description = "Number of days after which to transition cloudtrail objects to glacier storage"
+  default     = 365
+}
+
+variable "cloudtrail_noncurrent_version_glacier_transition_days" {
+  type        = number
+  description = "Number of days after which to transition cloudtrail noncurrent versions to glacier storage"
+  default     = 365
+}


### PR DESCRIPTION
## what
* allow users to change lifecycle fields
* different lifecycle parameters for archive vs cloudtrail

## why
* I want to be able to expire objects, i also don't need to move objects to glacier
* Allows users to set their own lifecycle rules



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced advanced lifecycle configuration options for archive and CloudTrail storage, allowing more granular control over transitions, expirations, and storage class management.
* **Refactor**
  * Consolidated multiple individual lifecycle settings into structured configuration objects for easier management and extensibility.
* **Chores**
  * Updated default values and streamlined variable handling for improved clarity and flexibility in storage lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->