### PR TITLE
Fix cloudtrail s3 bucket name

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "default" {
     ]
 
     resources = [
-      "arn:${local.aws_partition}:s3:::${module.this.id}-cloudtrail",
+      "arn:${local.aws_partition}:s3:::${module.cloudtrail_label.id}",
     ]
   }
 
@@ -80,7 +80,7 @@ data "aws_iam_policy_document" "default" {
     ]
 
     resources = [
-      "arn:${local.aws_partition}:s3:::${module.this.id}-cloudtrail/*",
+      "arn:${local.aws_partition}:s3:::${module.cloudtrail_label.id}/*",
     ]
 
     condition {
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "default" {
     ]
 
     resources = [
-      "arn:${local.aws_partition}:s3:::${module.this.id}-cloudtrail/*",
+      "arn:${local.aws_partition}:s3:::${module.cloudtrail_label.id}/*",
     ]
 
     condition {
@@ -216,6 +216,15 @@ module "archive_bucket" {
   context = module.this.context
 }
 
+module "cloudtrail_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  name    = "datadog-logs-archive-cloudtrail"
+  context = module.this.context
+}
+
+
 module "cloudtrail_s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
   version = "4.10.0"
@@ -224,7 +233,6 @@ module "cloudtrail_s3_bucket" {
 
   count = local.enabled ? 1 : 0
 
-  name          = "datadog-logs-archive-cloudtrail"
   acl           = "private"
   enabled       = local.enabled
   force_destroy = var.s3_force_destroy
@@ -282,7 +290,7 @@ module "cloudtrail_s3_bucket" {
   # https://github.com/hashicorp/terraform/issues/5613
   allow_ssl_requests_only = false
 
-  context = module.this.context
+  context = module.cloudtrail_label.context
 }
 
 module "cloudtrail" {

--- a/src/main.tf
+++ b/src/main.tf
@@ -29,7 +29,7 @@ locals {
 
   # default datadog_logs_archive query. 
   default_query = join(" OR ", concat([join(":", ["env", var.stage]), join(":", ["account", local.aws_account_id])], var.additional_query_tags))
-  query = var.query_override == null ? local.default_query : var.query_override
+  query         = var.query_override == null ? local.default_query : var.query_override
 }
 
 # We use the http data source due to lack of a data source for datadog_logs_archive_order

--- a/src/main.tf
+++ b/src/main.tf
@@ -29,7 +29,6 @@ locals {
 
   # default datadog_logs_archive query. 
   default_query = join(" OR ", concat([join(":", ["env", var.stage]), join(":", ["account", local.aws_account_id])], var.additional_query_tags))
-  
   query = var.query_override == null ? local.default_query : var.query_override
 }
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -4,9 +4,8 @@ variable "region" {
 }
 
 variable "query_override" {
-  type        = string
+  type        = optional(string)
   description = "Override query for datadog archive. If null would be used query 'env:{stage} OR account:{aws account id} OR {additional_query_tags}'"
-  default     = null
 }
 
 variable "additional_query_tags" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -4,7 +4,8 @@ variable "region" {
 }
 
 variable "query_override" {
-  type        = optional(string)
+  type        = string
+  nullable    = true
   description = "Override query for datadog archive. If null would be used query 'env:{stage} OR account:{aws account id} OR {additional_query_tags}'"
 }
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -3,6 +3,12 @@ variable "region" {
   description = "AWS Region"
 }
 
+variable "query_override" {
+  type        = string
+  description = "Override query for datadog archive. If null would be used query 'env:{stage} OR account:{aws account id} OR {additional_query_tags}'"
+  default     = null
+}
+
 variable "additional_query_tags" {
   type        = list(any)
   description = "Additional tags to be used in the query for this archive"


### PR DESCRIPTION
## what
* Use own the CloudTrail's S3 bucket name null/label module
* Added `query_override` variable

## why
* Have a single source of truth S3 bucket name module. We can not rely on the S3 bucket output, as there is a dependency loop that has to be solved.
* Allow to specify a custom query

## references
* https://github.com/cloudposse-terraform-components/aws-datadog-logs-archive/issues/71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional query override to customize the Datadog archive query; additional query tags now configurable.

* **Chores**
  * Introduced a dedicated label/context for CloudTrail resources and updated bucket, policy, and archive references to use it for consistent naming and policies.
  * Archive query selection now uses a local default-or-override mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->