### PR TITLE
Add S3 access logging for CloudTrail bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ components:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.19 |
-| <a name="provider_http"></a> [http](#provider\_http) | >= 2.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.82.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.5.0 |
 
 ## Modules
 
@@ -153,6 +153,8 @@ components:
 | <a name="module_archive_bucket"></a> [archive\_bucket](#module\_archive\_bucket) | cloudposse/s3-bucket/aws | 4.10.0 |
 | <a name="module_bucket_policy"></a> [bucket\_policy](#module\_bucket\_policy) | cloudposse/iam-policy/aws | 2.0.2 |
 | <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | cloudposse/cloudtrail/aws | 0.24.0 |
+| <a name="module_cloudtrail_access_log_bucket"></a> [cloudtrail\_access\_log\_bucket](#module\_cloudtrail\_access\_log\_bucket) | cloudposse/s3-bucket/aws | 4.10.0 |
+| <a name="module_cloudtrail_access_log_bucket_label"></a> [cloudtrail\_access\_log\_bucket\_label](#module\_cloudtrail\_access\_log\_bucket\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_cloudtrail_bucket_label"></a> [cloudtrail\_bucket\_label](#module\_cloudtrail\_bucket\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_cloudtrail_s3_bucket"></a> [cloudtrail\_s3\_bucket](#module\_cloudtrail\_s3\_bucket) | cloudposse/s3-bucket/aws | 4.10.0 |
 | <a name="module_datadog_configuration"></a> [datadog\_configuration](#module\_datadog\_configuration) | github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys | v1.535.12 |
@@ -179,6 +181,7 @@ components:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_access_log_bucket_name"></a> [access\_log\_bucket\_name](#input\_access\_log\_bucket\_name) | Name of existing S3 bucket to use for CloudTrail bucket access logs. Only used when create\_access\_log\_bucket is false | `string` | `""` | no |
 | <a name="input_additional_query_tags"></a> [additional\_query\_tags](#input\_additional\_query\_tags) | Additional tags to be used in the query for this archive | `list(any)` | `[]` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_archive_lifecycle_config"></a> [archive\_lifecycle\_config](#input\_archive\_lifecycle\_config) | Lifecycle configuration for the archive S3 bucket | <pre>object({<br/>    abort_incomplete_multipart_upload_days         = optional(number, null)<br/>    enable_glacier_transition                      = optional(bool, true)<br/>    glacier_transition_days                        = optional(number, 365)<br/>    noncurrent_version_glacier_transition_days     = optional(number, 30)<br/>    enable_deeparchive_transition                  = optional(bool, false)<br/>    deeparchive_transition_days                    = optional(number, 0)<br/>    noncurrent_version_deeparchive_transition_days = optional(number, 0)<br/>    enable_standard_ia_transition                  = optional(bool, false)<br/>    standard_transition_days                       = optional(number, 0)<br/>    expiration_days                                = optional(number, 0)<br/>    noncurrent_version_expiration_days             = optional(number, 0)<br/>  })</pre> | `{}` | no |
@@ -191,6 +194,7 @@ components:
 | <a name="input_cloudtrail_kms_key_enable_rotation"></a> [cloudtrail\_kms\_key\_enable\_rotation](#input\_cloudtrail\_kms\_key\_enable\_rotation) | Enable automatic rotation of the KMS key | `bool` | `true` | no |
 | <a name="input_cloudtrail_lifecycle_config"></a> [cloudtrail\_lifecycle\_config](#input\_cloudtrail\_lifecycle\_config) | Lifecycle configuration for the cloudtrail S3 bucket | <pre>object({<br/>    abort_incomplete_multipart_upload_days         = optional(number, null)<br/>    enable_glacier_transition                      = optional(bool, true)<br/>    glacier_transition_days                        = optional(number, 365)<br/>    noncurrent_version_glacier_transition_days     = optional(number, 365)<br/>    enable_deeparchive_transition                  = optional(bool, false)<br/>    deeparchive_transition_days                    = optional(number, 0)<br/>    noncurrent_version_deeparchive_transition_days = optional(number, 0)<br/>    enable_standard_ia_transition                  = optional(bool, false)<br/>    standard_transition_days                       = optional(number, 0)<br/>    expiration_days                                = optional(number, 0)<br/>    noncurrent_version_expiration_days             = optional(number, 0)<br/>  })</pre> | `{}` | no |
 | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
+| <a name="input_create_access_log_bucket"></a> [create\_access\_log\_bucket](#input\_create\_access\_log\_bucket) | Whether to create a dedicated S3 bucket for CloudTrail bucket access logs | `bool` | `false` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>  format = string<br/>  labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -219,6 +223,9 @@ components:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_access_log_bucket_arn"></a> [access\_log\_bucket\_arn](#output\_access\_log\_bucket\_arn) | The ARN of the bucket used for CloudTrail bucket access logs |
+| <a name="output_access_log_bucket_domain_name"></a> [access\_log\_bucket\_domain\_name](#output\_access\_log\_bucket\_domain\_name) | The FQDN of the bucket used for CloudTrail bucket access logs |
+| <a name="output_access_log_bucket_id"></a> [access\_log\_bucket\_id](#output\_access\_log\_bucket\_id) | The ID (name) of the bucket used for CloudTrail bucket access logs |
 | <a name="output_archive_id"></a> [archive\_id](#output\_archive\_id) | The ID of the environment-specific log archive |
 | <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | The ARN of the bucket used for log archive storage |
 | <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | The FQDN of the bucket used for log archive storage |

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -59,16 +59,16 @@ output "cloudtrail_kms_key_alias" {
 }
 
 output "access_log_bucket_id" {
-  value       = local.enabled && var.create_access_log_bucket ? module.cloudtrail_access_log_bucket[0].bucket_id : ""
+  value       = local.enabled && var.access_log_bucket_enabled ? module.cloudtrail_access_log_bucket[0].bucket_id : ""
   description = "The ID (name) of the bucket used for CloudTrail bucket access logs"
 }
 
 output "access_log_bucket_arn" {
-  value       = local.enabled && var.create_access_log_bucket ? module.cloudtrail_access_log_bucket[0].bucket_arn : ""
+  value       = local.enabled && var.access_log_bucket_enabled ? module.cloudtrail_access_log_bucket[0].bucket_arn : ""
   description = "The ARN of the bucket used for CloudTrail bucket access logs"
 }
 
 output "access_log_bucket_domain_name" {
-  value       = local.enabled && var.create_access_log_bucket ? module.cloudtrail_access_log_bucket[0].bucket_domain_name : ""
+  value       = local.enabled && var.access_log_bucket_enabled ? module.cloudtrail_access_log_bucket[0].bucket_domain_name : ""
   description = "The FQDN of the bucket used for CloudTrail bucket access logs"
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -57,3 +57,18 @@ output "cloudtrail_kms_key_alias" {
   value       = local.enabled && var.cloudtrail_enable_kms_encryption && var.cloudtrail_create_kms_key && var.cloudtrail_kms_key_arn == null ? aws_kms_alias.cloudtrail[0].name : ""
   description = "The alias of the KMS key used for CloudTrail log encryption (only if created by this module)"
 }
+
+output "access_log_bucket_id" {
+  value       = local.enabled && var.create_access_log_bucket ? module.cloudtrail_access_log_bucket[0].bucket_id : ""
+  description = "The ID (name) of the bucket used for CloudTrail bucket access logs"
+}
+
+output "access_log_bucket_arn" {
+  value       = local.enabled && var.create_access_log_bucket ? module.cloudtrail_access_log_bucket[0].bucket_arn : ""
+  description = "The ARN of the bucket used for CloudTrail bucket access logs"
+}
+
+output "access_log_bucket_domain_name" {
+  value       = local.enabled && var.create_access_log_bucket ? module.cloudtrail_access_log_bucket[0].bucket_domain_name : ""
+  description = "The FQDN of the bucket used for CloudTrail bucket access logs"
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -126,7 +126,7 @@ variable "cloudtrail_kms_key_enable_rotation" {
   default     = true
 }
 
-variable "create_access_log_bucket" {
+variable "access_log_bucket_enabled" {
   type        = bool
   description = "Whether to create a dedicated S3 bucket for CloudTrail bucket access logs"
   default     = false
@@ -134,6 +134,6 @@ variable "create_access_log_bucket" {
 
 variable "access_log_bucket_name" {
   type        = string
-  description = "Name of existing S3 bucket to use for CloudTrail bucket access logs. Only used when create_access_log_bucket is false"
+  description = "Name of existing S3 bucket to use for CloudTrail bucket access logs. Only used when access_log_bucket_enabled is false"
   default     = ""
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -126,4 +126,14 @@ variable "cloudtrail_kms_key_enable_rotation" {
   default     = true
 }
 
+variable "create_access_log_bucket" {
+  type        = bool
+  description = "Whether to create a dedicated S3 bucket for CloudTrail bucket access logs"
+  default     = false
+}
 
+variable "access_log_bucket_name" {
+  type        = string
+  description = "Name of existing S3 bucket to use for CloudTrail bucket access logs. Only used when create_access_log_bucket is false"
+  default     = ""
+}


### PR DESCRIPTION
## Summary
Enable S3 server access logging for the datadog-logs-archive-cloudtrail bucket to meet Drata compliance controls. This follows the same pattern implemented in the aws-cloudtrail-bucket component.

## Changes
- Add `access_log_bucket_enabled ` and `access_log_bucket_name` variables to support creating or using an existing access log bucket
- Implement dedicated access log bucket with proper naming and tagging
- Configure CloudTrail bucket logging to send access logs to the designated bucket
- Export access log bucket details via new outputs (ID, ARN, domain name)

## Testing
The Terraform configuration has been validated syntactically. Users can enable logging by setting `access_log_bucket_enabled: true` or provide an existing bucket name via `access_log_bucket_name`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CloudTrail access logging support with an option to use or provision a dedicated S3 access-log bucket
  * Public inputs to control access-log bucket creation and name
  * Public outputs exposing access-log bucket ID, ARN, and domain name
  * Added public modules to provision and label the optional access-log bucket

* **Chores**
  * Provider version constraints pinned to specific stable releases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->