### PR TITLE
fix: Remove deprecated Terraform syntax

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -2,13 +2,13 @@
 locals {
   enabled = module.this.enabled
 
-  aws_account_id = join("", data.aws_caller_identity.current.*.account_id)
-  aws_partition  = join("", data.aws_partition.current.*.partition)
+  aws_account_id = join("", data.aws_caller_identity.current[*].account_id)
+  aws_partition  = join("", data.aws_partition.current[*].partition)
 
   create_access_log_bucket = local.enabled && (var.access_log_bucket_enabled || var.access_log_bucket_name != "")
   access_log_bucket_name   = var.access_log_bucket_enabled ? one(module.cloudtrail_access_log_bucket[*].bucket_id) : var.access_log_bucket_name
 
-  datadog_aws_role_name = nonsensitive(join("", data.aws_ssm_parameter.datadog_aws_role_name.*.value))
+  datadog_aws_role_name = nonsensitive(join("", data.aws_ssm_parameter.datadog_aws_role_name[*].value))
   principal_names = [
     format("arn:${local.aws_partition}:iam::%s:role/${local.datadog_aws_role_name}", local.aws_account_id),
   ]
@@ -20,7 +20,7 @@ locals {
   ]
 
   # in case enabled: false and we have no current order to lookup
-  data_current_order_body = one(data.http.current_order.*.response_body) == null ? {} : jsondecode(data.http.current_order[0].response_body)
+  data_current_order_body = one(data.http.current_order[*].response_body) == null ? {} : jsondecode(data.http.current_order[0].response_body)
   # in case there is no response (valid http request but no existing data)
   current_order_data = lookup(local.data_current_order_body, "data", null)
 
@@ -155,7 +155,7 @@ module "bucket_policy" {
   source  = "cloudposse/iam-policy/aws"
   version = "2.0.2"
 
-  iam_policy_statements = try(lookup(local.policy, "Statement"), null)
+  iam_policy_statements = try(local.policy["Statement"], null)
 
   context = module.this.context
 }
@@ -286,7 +286,7 @@ module "cloudtrail_s3_bucket" {
   enabled       = local.enabled
   force_destroy = var.s3_force_destroy
 
-  source_policy_documents = data.aws_iam_policy_document.default.*.json
+  source_policy_documents = data.aws_iam_policy_document.default[*].json
 
   lifecycle_rules = [
     {


### PR DESCRIPTION
## Why

Deprecated HCL syntax triggers linting warnings and will eventually be removed in future Terraform versions. Cleaning these up improves code quality, maintainability, and ensures forward compatibility.

## What

Automated fixes applied via `tflint --fix` with the following rules enabled:

| Rule | Description | Example |
|------|-------------|---------|
| `terraform_deprecated_interpolation` | Remove unnecessary interpolation wrappers | `"${var.foo}"` → `var.foo` |
| `terraform_deprecated_index` | Replace legacy dot-index syntax | `list.0` → `list[0]` |
| `terraform_deprecated_lookup` | Replace deprecated `lookup()` calls | `lookup(map, key)` → `map[key]` |

## References

- [tflint terraform_deprecated_interpolation](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_interpolation.md)
- [tflint terraform_deprecated_index](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_index.md)
- [tflint terraform_deprecated_lookup](https://github.com/terraform-linters/tflint-ruleset-terraform/blob/main/docs/rules/terraform_deprecated_lookup.md)
- [Terraform: References to Named Values](https://developer.hashicorp.com/terraform/language/expressions/references)